### PR TITLE
Add explicit Microsoft.Bcl.AsyncInterfaces 10.0.10 to host for plugin binder roll-forward

### DIFF
--- a/MicrotingService/MicrotingService.csproj
+++ b/MicrotingService/MicrotingService.csproj
@@ -29,6 +29,7 @@
       <ItemGroup>
             <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1.1" />
             <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
+            <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
             <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
             <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
             <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.10" />


### PR DESCRIPTION
## Why

`eform-service-backendconfiguration-plugin` now depends on **FirebaseAdmin 3.6.0**, which pulls **Google.Api.Gax 4.13.1** whose assemblies reference **Microsoft.Bcl.AsyncInterfaces 6.0.0.0**. The host (`MicrotingService`) currently ships **Microsoft.Bcl.AsyncInterfaces 5.0.0.0** (transitive via `System.Private.ServiceModel` 4.10.3).

MEF's `DirectoryCatalog` loads plugins into the default load context, and the .NET binder will not roll the already-loaded 5.0.0.0 assembly forward to satisfy the plugin's 6.0.0.0 reference. The result in production would be a `FileLoadException` during plugin composition and an NRE at `ServiceLogic.Start` when the composed import is null.

## What

Adds an explicit `<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />` to `MicrotingService/MicrotingService.csproj`. NuGet then resolves 10.0.10 (assembly version 10.0.0.0) for the whole graph, so the single copy deployed next to `MicrotingService.dll` satisfies both the host's 5.0.0.0 request and the plugin's 6.0.0.0 request via standard roll-forward.

Verified locally: `dotnet build MicrotingService.sln` is clean and `obj/project.assets.json` resolves `Microsoft.Bcl.AsyncInterfaces/10.0.10`; the DLL is copied to the output directory (`CopyLocalLockFileAssemblies=true`).

## Deployment ordering (important)

The plugin repo's CI Dockerfile was already patched with the same reference at image build time. This PR puts the fix in the host repo itself: it **must be merged and the docker image rebuilt before the eform-service-backendconfiguration-plugin reminder-push release reaches production**, otherwise the plugin will fail to compose at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)